### PR TITLE
draft: feat: whisper prompt for skyrim setting and herika name

### DIFF
--- a/stt/stt-whisper.php
+++ b/stt/stt-whisper.php
@@ -15,7 +15,8 @@ function stt($file) {
       'model' => 'whisper-1',
       'file' => fopen($file, 'r'),
       'response_format' => 'verbose_json',
-      'language'=>$GLOBALS["TTSLANGUAGE_WHISPER"]
+      'language'=>$GLOBALS["TTSLANGUAGE_WHISPER"],
+      'prompt'=>'Herika, the Dragonborns are taking the Nords to Whiterun! Check that bard\'s lute! Fus Ro Dah!'
   ]);
 
   return $response["text"];


### PR DESCRIPTION
Eventhough not documented in the PHP Client's docs, Whisper STT allows for a prompt value to be passed in the request body:
https://github.com/openai-php/client/blob/main/README.md
https://platform.openai.com/docs/api-reference/audio/create
https://platform.openai.com/docs/guides/speech-to-text/prompting

Since all of the values are simply passed to the API this "should" work 🤞